### PR TITLE
Update docs to fix local-tld config path for custom Node installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Prerequisits:
 
 * Node.JS
-  
+
   Either hit the big green “Install” button on http://nodejs.org
 
   Or, if you are using Homebrew:
@@ -11,7 +11,7 @@ Prerequisits:
   `$ brew install node`
 
 * CouchDB
-  
+
   `$ brew install couchdb`
 
 (If any of these fail, run `brew update` to make sure your Homebrew version is up to date.)
@@ -80,13 +80,24 @@ Make sure that local-tld got installed correctly
     $ NODE_PATH=`npm root -g`
     $ open $NODE_PATH/local-tld
 
-Make sure, that paths have been set corretly
+Make sure that paths have been set correctly
 
     $ echo $NODE_PATH
     $ cat ~/Library/LaunchAgents/ie.hood.local-tld-service.plist
 
-You should see `<string>/usr/local/lib/node_modules/local-tld/bin/local-tld-service</string>`,
-`/usr/local/lib/node_modules` being what `$ npm root -g` returns.
+In some situations, you may need to manually update `~/Library/LaunchAgents/ie.hood.local-tld-service.plist` to correctly source your Node installation, particularly if you are using a Node version manager, such as `nvm`.
+
+Check the output of `$ cat ~/Library/LaunchAgents/ie.hood.local-tld-service.plist` for the following:
+
+```
+<key>ProgramArguments</key>
+<array>
+    <string>should equal the output of `$ which node`</string>
+    <string>should equal the output of `$ echo $NODE_PATH` + /local-tld/bin/local-tld-service</string>
+</array>
+```
+
+If these values aren't correct, you'll need to open `~/Library/LaunchAgents/ie.hood.local-tld-service.plist` in a text editor and update the file with the aforementioned values.
 
 If things do not work, try:
 


### PR DESCRIPTION
I was on IRC earlier asking about an issue where `hoodie start` would time out as `hoodie` could not locate the DB. I've managed to track the issue down to an incorrect Node path set in `~/Library/LaunchAgents/ie.hood.local-tld-service.plist`.

The file originally looked like this:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>Label</key>
        <string>ie.hood.local-tld-service</string>
        <key>ProgramArguments</key>
        <array>
                <string>/usr/local/bin/node</string>
                <string>/Users/adamyeats/.nvm/v0.10.5/lib/node_modules/local-tld/bin/local-tld-service</string>
        </array>
        <key>KeepAlive</key>
        <true/>
        <key>RunAtLoad</key>
        <true/>
</dict>
</plist>
```

Updating it to this fixed the issue:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>Label</key>
        <string>ie.hood.local-tld-service</string>
        <key>ProgramArguments</key>
        <array>
                <string>/Users/adamyeats/.nvm/v0.10.5/bin/node</string>
                <string>/Users/adamyeats/.nvm/v0.10.5/lib/node_modules/local-tld/bin/local-tld-service</string>
        </array>
        <key>KeepAlive</key>
        <true/>
        <key>RunAtLoad</key>
        <true/>
</dict>
</plist>
```

This pull request is intended to make the language of the troubleshooting section a little clearer, and to give an explicit mention to the fact that custom Node installations appear not to be supported by `local-tld` yet. Please get back to me if there are any changes you'd like me to make.
