### PR TITLE
Adding references to necessary plugins for a minimally useful my-first-hoodie#plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "type": "app",
   "dependencies": {
     "hoodie-server": "git://github.com/hoodiehq/hoodie-server.git#plugins",
-    "hoodie-plugin-users": "git://github.com/hoodiehq/worker-users.git#new_plugin_architecture"
+    "hoodie-plugin-appconfig": "git://github.com/hoodiehq/hoodie-plugin-appconfig.git",
+    "hoodie-plugin-email": "git://github.com/hoodiehq/hoodie-plugin-email.git",
+    "hoodie-plugin-users": "git://github.com/hoodiehq/hoodie-plugin-users.git"
   },
   "scripts": {
     "start": "node node_modules/hoodie-server/bin/start"


### PR DESCRIPTION
Adding references to necessary plugins for a minimally useful my-first-hoodie#plugins
I also changed the hoodie-plugin-users to point to the actual repo of that name, rather than a branch of worker-users.

Without these additional plugins installed, the #plugins branch looks much less functional that it actually is.
