### PR TITLE
Add `-m` flag to `useradd` to create home dir

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -48,6 +48,7 @@ Create a new system user:
 
 ```
 useradd --system \
+       -m \
        --home /home/hoodie \
        --shell /bin/bash \
        --no-user-group \


### PR DESCRIPTION
Not sure if it's just me, but I needed to add `-m`, otherwise `/home/hoodie` wasn't created (Ubuntu).
