### PR TITLE
Should use caret symbol in package.json dependencies to get fixes automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.17",
   "type": "app",
   "dependencies": {
-    "hoodie-server": "0.9.24",
-    "hoodie-plugin-appconfig": "~0.1.0",
-    "hoodie-plugin-email": "~0.1.1",
-    "hoodie-plugin-users": "0.1.0"
+    "hoodie-server": "^0.9.24",
+    "hoodie-plugin-appconfig": "^0.1.0",
+    "hoodie-plugin-email": "^0.1.1",
+    "hoodie-plugin-users": "^0.1.0"
   },
   "engines": {
     "node": ">=0.10.22"


### PR DESCRIPTION
As it is the new default of npm, I would recomment using caret symbol. This will automatically install fixes when running `npm install`.

No need to merge, you can do it on your own, of course. Just wanted to make it as easy as possible ;)
