### PR TITLE
feat(package): bundle dependencies for faster and deterministic installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,27 +1,33 @@
 {
   "name": "my-first-hoodie",
   "version": "3.1.0",
-  "type": "app",
+  "bundleDependencies": [
+    "hoodie-plugin-appconfig",
+    "hoodie-plugin-email",
+    "hoodie-plugin-users",
+    "hoodie-server"
+  ],
   "dependencies": {
     "hoodie-plugin-appconfig": "^2.0.1",
     "hoodie-plugin-email": "^1.0.0",
     "hoodie-plugin-users": "^2.2.2",
     "hoodie-server": "^4.0.1"
   },
-  "files": [
-    "www/"
-  ],
   "engines": {
     "node": ">=0.10.22"
   },
-  "scripts": {
-    "start": "node node_modules/hoodie-server/bin/start"
-  },
+  "files": [
+    "www/"
+  ],
   "hoodie": {
     "plugins": [
       "hoodie-plugin-appconfig",
       "hoodie-plugin-email",
       "hoodie-plugin-users"
     ]
-  }
+  },
+  "scripts": {
+    "start": "node node_modules/hoodie-server/bin/start"
+  },
+  "type": "app"
 }


### PR DESCRIPTION
This causes the dependencies to be bundled into the tarball by npm on publish time.
The users npm doesn't have to install dependencies one-by-one then.

I think this should make installs faster and on top of the `shrinkwrap.json` it's the way to make this template deterministic in so far that installing a certain version of "my-first-hoodie" gives you exactly the same thing every single time.

I've just published a preversion using bundleDependencies. You can test it using this command:

`hoodie new myApp -t my-first-hoodie@3.1.1-bundled-dependencies`.