### PR TITLE
Bit of styling and rewording

### DIFF
--- a/www/assets/app.css
+++ b/www/assets/app.css
@@ -22,7 +22,46 @@ h1, h4 {
 h1 {
   border-bottom: 2px solid #222;
   text-align: left;
+  line-height: 1.5;
 }
+
+button {
+  border-radius: 5px;
+  background: #CCC;
+  border: none;
+}
+
+p button {
+  font-size: 0.8em;
+  font-weight: bold;
+  padding: 3px 5px;
+}
+
+input,
+textarea,
+table{
+  border: 1px solid #aaa;
+}
+
+textarea{
+  height: 3.25em;
+  max-width: 100%;
+}
+
+button:hover,
+button:focus,
+input[type="text"]:hover,
+input[type="text"]:focus,
+input[type="number"]:focus,
+input[type="number"]:hover,
+textarea:hover,
+textarea:focus{
+  border-color: transparent;
+  outline: none;
+  box-shadow: 0 0 0 3px #222;
+}
+
+
 
 /* Layout */
 
@@ -82,6 +121,13 @@ h1 {
 .table th,
 .table td {
   padding: 1rem;
+  text-align: left;
+}
+
+.table th:first-child,
+.table td:first-child {
+  padding: 1rem;
+  text-align: right;
 }
 
 .table td {
@@ -108,7 +154,7 @@ h1 {
   }
 }
 
-#login-form {
+#signin-form {
   text-align: right;
   padding-bottom: 2rem;
 }

--- a/www/assets/app.css
+++ b/www/assets/app.css
@@ -115,6 +115,10 @@ textarea {
   border: 1px solid #aaa;
 }
 
+.table th:first-child{
+  width: 20%;
+}
+
 .btn:focus,
 .form-input:focus {
   border-color: transparent;

--- a/www/assets/app.css
+++ b/www/assets/app.css
@@ -158,3 +158,7 @@ textarea:focus{
   text-align: right;
   padding-bottom: 2rem;
 }
+
+#signedin-message {
+  text-align: right;
+}

--- a/www/assets/app.css
+++ b/www/assets/app.css
@@ -3,6 +3,7 @@
 html {
   box-sizing: border-box;
   font-size: 16px;
+  color: #222;
 }
 
 *, *:after, *:before {
@@ -21,47 +22,13 @@ h1, h4 {
 
 h1 {
   border-bottom: 2px solid #222;
-  text-align: left;
   line-height: 1.5;
 }
 
-button {
-  border-radius: 5px;
-  background: #CCC;
-  border: none;
-}
-
-p button {
-  font-size: 0.8em;
-  font-weight: bold;
-  padding: 3px 5px;
-}
-
-input,
-textarea,
-table{
-  border: 1px solid #aaa;
-}
-
-textarea{
+textarea {
   height: 3.25em;
   max-width: 100%;
 }
-
-button:hover,
-button:focus,
-input[type="text"]:hover,
-input[type="text"]:focus,
-input[type="number"]:focus,
-input[type="number"]:hover,
-textarea:hover,
-textarea:focus{
-  border-color: transparent;
-  outline: none;
-  box-shadow: 0 0 0 3px #222;
-}
-
-
 
 /* Layout */
 
@@ -83,6 +50,16 @@ textarea:focus{
   margin-right: 1rem;
 }
 
+/* Clearfix */
+.grid > .grid-col:before,
+.grid > .grid-col:after {
+  content: " ";
+  display: table;
+}
+.grid > .grid-col:after {
+  clear: both;
+}
+
 @media (min-width: 768px) {
   .grid > .grid-col {
     float: left;
@@ -92,26 +69,86 @@ textarea:focus{
 
 /* Components */
 
-.form-label,
-.form-input,
-.table {
-  width: 100%;
-  margin-bottom: 1rem;
-}
-
 .form-input {
   padding: 1rem;
 }
 
 .form-label {
-    display: inline-block;
-    font-weight: bold;
+  display: inline-block;
+  font-weight: bold;
 }
 
 .btn {
   display: inline-block;
   padding: 1rem;
   margin-bottom: 1rem;
+  border-radius: 5px;
+  background: #CCC;
+  border: none;
+}
+
+.btn + .btn-small {
+  margin-left: .5rem;
+}
+
+.form-label-small,
+.form-input-small,
+.btn-small {
+  font-size: .8rem;
+}
+
+.form-input-small,
+.btn-small {
+  padding: .5rem;
+}
+
+.form-label,
+.form-input,
+.textarea,
+.table {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.form-input,
+.table {
+  border: 1px solid #aaa;
+}
+
+.btn:focus,
+.form-input:focus {
+  border-color: transparent;
+  outline: none;
+  box-shadow: 0 0 0 2px #222;
+}
+
+/* Clearfix */
+.form:before,
+.form:after {
+  content: " ";
+  display: table;
+}
+.form:after {
+  clear: both;
+}
+
+
+@media (min-width: 768px) {
+  .form-inline .form-label,
+  .form-inline .form-input {
+    display: inline-block;
+    width: auto;
+  }
+
+  .form-inline .form-input-small {
+    margin-left: .5rem;
+    margin-right: .5rem;
+  }
+  .form-inline .form-label-small {
+    padding-top: .5rem;
+    padding-bottom: .5rem;
+    margin-bottom: 0;
+  }
 }
 
 .table {
@@ -144,6 +181,10 @@ textarea:focus{
   text-align: center;
 }
 
+.text-right {
+  text-align: right;
+}
+
 .pull-right {
   float: right;
 }
@@ -152,13 +193,4 @@ textarea:focus{
   .full-width-small {
     width: 100%;
   }
-}
-
-#signin-form {
-  text-align: right;
-  padding-bottom: 2rem;
-}
-
-#signedin-message {
-  text-align: right;
 }

--- a/www/assets/app.js
+++ b/www/assets/app.js
@@ -1,7 +1,7 @@
-var $signinForm = document.querySelector('#signin-form')
-var $signedinMessage = document.querySelector('#signedin-message')
-var $signupButton = document.querySelector('#button-signup')
-var $signoutButton = document.querySelector('#button-signout')
+var $signinForm = document.querySelector('.js-signin-form')
+var $signedinMessage = document.querySelector('.js-signedin-message')
+var $signupButton = document.querySelector('.js-signup-btn')
+var $signoutButton = document.querySelector('.js-signout-btn')
 
 var $trackerForm = document.querySelector('.js-tracker-input')
 var $trackerOutput = document.querySelector('.js-tracker-output')
@@ -123,13 +123,13 @@ function addNote (note) {
 
 function showSignedIn (username) {
   document.querySelector('.js-username').textContent = username
-  $signedinMessage.style.display = 'block'
-  $signinForm.style.display = 'none'
+  $signedinMessage.classList.remove('hide');
+  $signinForm.classList.add('hide');
 }
 
 function hideSignedIn () {
-  $signedinMessage.style.display = 'none'
-  $signinForm.style.display = 'block'
+  $signedinMessage.classList.add('hide');
+  $signinForm.classList.remove('hide');
 }
 
 hoodie.account.on('signin', function (account) {

--- a/www/assets/app.js
+++ b/www/assets/app.js
@@ -1,17 +1,17 @@
-var $loginForm = document.querySelector('#login-form')
-var $loggedinMessage = document.querySelector('#loggedin-message')
-var $registerButton = document.querySelector('#button-register')
-var $logoutButton = document.querySelector('#button-logout')
+var $signinForm = document.querySelector('#signin-form')
+var $signedinMessage = document.querySelector('#signedin-message')
+var $signupButton = document.querySelector('#button-signup')
+var $signoutButton = document.querySelector('#button-signout')
 
 var $trackerForm = document.querySelector('.js-tracker-input')
 var $trackerOutput = document.querySelector('.js-tracker-output')
 var $trackerClearButton = document.querySelector('.js-tracker-clear')
 
-$loginForm.addEventListener('submit', function (event) {
+$signinForm.addEventListener('submit', function (event) {
   event.preventDefault()
 
-  var username = $loginForm.querySelector('[name=username]').value
-  var password = $loginForm.querySelector('[name=password]').value
+  var username = $signinForm.querySelector('[name=username]').value
+  var password = $signinForm.querySelector('[name=password]').value
 
   hoodie.account.signIn({
     username: username,
@@ -23,11 +23,11 @@ $loginForm.addEventListener('submit', function (event) {
   })
 })
 
-$registerButton.addEventListener('click', function (event) {
+$signupButton.addEventListener('click', function (event) {
   event.preventDefault()
 
-  var username = $loginForm.querySelector('[name=username]').value
-  var password = $loginForm.querySelector('[name=password]').value
+  var username = $signinForm.querySelector('[name=username]').value
+  var password = $signinForm.querySelector('[name=password]').value
 
   hoodie.account.signUp({
     username: username,
@@ -46,7 +46,7 @@ $registerButton.addEventListener('click', function (event) {
   })
 })
 
-$logoutButton.addEventListener('click', function (event) {
+$signoutButton.addEventListener('click', function (event) {
   event.preventDefault()
 
   hoodie.account.signOut()
@@ -123,17 +123,17 @@ function addNote (note) {
 
 function showSignedIn (username) {
   document.querySelector('.js-username').textContent = username
-  $loggedinMessage.style.display = 'block'
-  $loginForm.style.display = 'none'
+  $signedinMessage.style.display = 'block'
+  $signinForm.style.display = 'none'
 }
 
 function hideSignedIn () {
-  $loggedinMessage.style.display = 'none'
-  $loginForm.style.display = 'block'
+  $signedinMessage.style.display = 'none'
+  $signinForm.style.display = 'block'
 }
 
 hoodie.account.on('signin', function (account) {
-  $loginForm.reset()
+  $signinForm.reset()
   showSignedIn(account.username)
 })
 hoodie.account.on('signout', hideSignedIn)

--- a/www/assets/normalize.css
+++ b/www/assets/normalize.css
@@ -1,0 +1,424 @@
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS and IE text size adjust after device orientation change,
+ *    without disabling user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  font-weight: bold;
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  box-sizing: content-box; /* 2 */
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
+   ========================================================================== */
+
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}

--- a/www/index.html
+++ b/www/index.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Something Tracker</title>
-    <link rel="stylesheet" href="https://necolas.github.io/normalize.css/3.0.2/normalize.css" />
+    <link rel="stylesheet" href="assets/normalize.css" />
     <link rel="stylesheet" href="assets/app.css" />
   </head>
   <body>
     <div class="container">
-      <form id="login-form">
+      <form id="signin-form">
         <label for="username">Username</label>
         <input
           name="username"
@@ -28,18 +28,18 @@
         <button
           name="sign-in"
           type="submit"
-        >Login</button>
+        >Sign in</button>
         <button
           name="sign-up"
           type="submit"
-          id="button-register"
-        >Register</button>
+          id="button-signup"
+        >Sign up</button>
       </form>
-      <p id="loggedin-message" style="display: none">
-        Hello there, <span class="js-username"></span>
+      <p id="signedin-message" style="display: none">
+        Hello there, <span class="js-username"></span>!
         <button
-          id="button-logout"
-        >Logout</button>
+          id="button-signout"
+        >Sign out</button>
       </p>
       <h1>Something Tracker</h1>
       <div class="grid">
@@ -64,7 +64,7 @@
             <button
               class="btn pull-right full-width-small"
               type="submit"
-            >Submit</button>
+            >Add item</button>
           <form>
         </div>
         <div class="grid-col">

--- a/www/index.html
+++ b/www/index.html
@@ -9,38 +9,51 @@
   </head>
   <body>
     <div class="container">
-      <form id="signin-form">
-        <label for="username">Username</label>
+      <form class="js-signin-form form form-inline">
+        <label
+          class="form-label form-label-small"
+          for="username"
+        >Username</label>
         <input
+          class="form-input form-input-small"
           name="username"
           id="username"
           width="200"
           required
         >
-        <label for="password">Password</label>
+        <label
+          class="form-label form-label-small"
+          for="password"
+        >Password</label>
         <input
+          class="form-input form-input-small"
+          id="password"
           name="password"
           type="password"
-          id="password"
           width="200"
           required
         >
-        <button
-          name="sign-in"
-          type="submit"
-        >Sign in</button>
-        <button
-          name="sign-up"
-          type="submit"
-          id="button-signup"
-        >Sign up</button>
+        <div class="text-right pull-right">
+          <button
+            class="btn btn-small"
+            name="sign-in"
+            type="submit"
+          >Sign in</button>
+          <button
+            class="js-signup-btn btn btn-small"
+            name="sign-up"
+            type="submit"
+          >Sign up</button>
+        </div>
       </form>
-      <p id="signedin-message" style="display: none">
-        Hello there, <span class="js-username"></span>!
-        <button
-          id="button-signout"
-        >Sign out</button>
-      </p>
+      <div class="js-signedin-message hide text-right">
+        <p>
+          Hello there, <span class="js-username"></span>!
+          <button
+            class="js-signout-btn btn btn-small"
+          >Sign out</button>
+        </p>
+      </div>
       <h1>Something Tracker</h1>
       <div class="grid">
         <div class="grid-col">
@@ -61,10 +74,12 @@
               id="note"
               required
             ></textarea>
-            <button
-              class="btn pull-right full-width-small"
-              type="submit"
-            >Add item</button>
+            <div class="text-right">
+              <button
+                class="btn full-width-small"
+                type="submit"
+              >Add item</button>
+            </div>
           <form>
         </div>
         <div class="grid-col">


### PR DESCRIPTION
Nicer buttons with hover and focus states, tidier text alignments, and `normalize.css` is now part of the repo, because I found myself working on this on the train, offline, unable to load it from github.

I also changed all instances of `login`, `log out` and `register` to `sign in`, `sign out` and `sign up` to match the Hoodie API.  

Also, `submit` is now `add item`, so that corresponds with the use of `item` in other places.

Now looks like this:

<img width="763" alt="bildschirmfoto 2016-01-01 um 13 53 03" src="https://cloud.githubusercontent.com/assets/391124/12070877/08171360-b08f-11e5-82e9-8a503743a6b7.png">
