### PR TITLE
docs(LICENSE): unify license accross all active repositories

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2012-2016 the Hoodie Community and other contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 > The default/welcome Hoodie app
 
 Look at [hoodiehq/hoodie](https://github.com/hoodiehq/hoodie) for further instructions.
+
+## License
+
+[Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "my-first-hoodie",
   "description": "The default/welcome Hoodie app",
-  "author": "The Hoodie Community",
+  "author": "The Hoodie Community and other contributors | http://hood.ie/",
   "bugs": {
     "url": "https://github.com/hoodiehq/my-first-hoodie/issues"
   },


### PR DESCRIPTION
This PR aims to unify the licenses accross all active repositories

It
- adds a _License_ section to the end of the `README.md`
- updates the `package.json` to include the correct `license` and `author` properties
- adds a small boilerplate `LICENSE` file

This PR is based on [hoodie-client-store#77](https://github.com/hoodiehq/hoodie-client-store/pull/77).
